### PR TITLE
Fix ItemStatue's display name sometimes being null

### DIFF
--- a/src/main/java/ganymedes01/headcrumbs/items/ItemStatue.java
+++ b/src/main/java/ganymedes01/headcrumbs/items/ItemStatue.java
@@ -92,6 +92,10 @@ public class ItemStatue extends FixedItemBlock {
 
 	@Override
 	public String getItemStackDisplayName(ItemStack stack) {
-		return HeadUtils.getName(stack);
+		String name = HeadUtils.getName(stack);
+		if (name == null) {
+			name = "(null)";
+		}
+		return name;
 	}
 }


### PR DESCRIPTION
Sometimes `HeadUtils.getName()` will return null if the stack is invalid or there's some other issue with the stack.

This was found in https://pastebin.com/raw/RdvFG6zX (BuildCraft/BuildCraft#4268)

<i>**(Committed on github directly, while I can't see any mistakes please change and/or compile this yourself to check that it still works)**</i>